### PR TITLE
Add COMPOSER_HOME as an environment variable to ss_env.erb

### DIFF
--- a/templates/ss_env.erb
+++ b/templates/ss_env.erb
@@ -72,3 +72,9 @@ if(isset($_SERVER['SCRIPT_FILENAME'])) {
 if(file_exists('<%= @master_file_dir %>/_ss_environment_secrets.php')) {
 	require_once('<%= @master_file_dir %>/_ss_environment_secrets.php');
 }
+
+<%# Temporary fix for defining COMPOSER_HOME required to prevent a permission error when executing the UpdatePackageInfoTask in module bringyourownideas/silverstripe-maintenance %>
+<%# See issue https://github.com/bringyourownideas/silverstripe-maintenance/issues/121 %>
+if (!getenv('COMPOSER_HOME')) {
+	putenv('COMPOSER_HOME=/tmp');
+}

--- a/templates/ss_env.erb
+++ b/templates/ss_env.erb
@@ -76,5 +76,6 @@ if(file_exists('<%= @master_file_dir %>/_ss_environment_secrets.php')) {
 <%# Temporary fix for defining COMPOSER_HOME required to prevent a permission error when executing the UpdatePackageInfoTask in module bringyourownideas/silverstripe-maintenance %>
 <%# See issue https://github.com/bringyourownideas/silverstripe-maintenance/issues/121 %>
 if (!getenv('COMPOSER_HOME')) {
-	putenv('COMPOSER_HOME=/tmp');
+	$tmpDir = sys_get_temp_dir();
+	putenv('COMPOSER_HOME=' . $tmpDir);
 }


### PR DESCRIPTION
This MR adds a definition of the COMPOSER_HOME environment variable into the ss_env.erb and finally _ss_environment.php.
The reason for that is to provide a generic solution to the issue described in https://github.com/bringyourownideas/silverstripe-maintenance/issues/121 and raised from https://www.cwp.govt.nz/service-desk/requests/?target=view.php%3Fid%3D33133.