### PR TITLE
Send errors to stderr when sake is run via sushi

### DIFF
--- a/files/deploy.ini
+++ b/files/deploy.ini
@@ -1,0 +1,2 @@
+error_log=""
+display_errors="stderr"

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -53,4 +53,12 @@ class ss_sushi (
 		group   => 'root',
 		mode    => '0700',
 	}
+
+	file { "${cli_root}/deploy.ini":
+		ensure => present,
+		owner  => $cli_owner,
+		group  => $cli_group,
+		source => 'puppet:///modules/ss_sushi/deploy.ini',
+		mode   => '0644',
+	}
 }

--- a/templates/sushi_script.erb
+++ b/templates/sushi_script.erb
@@ -40,4 +40,4 @@ fi
 chmod +x "$SAKE_PATH"
 
 # Preserves env
-sudo -E -u www-data "$SAKE_PATH" "$@"
+sudo -E -u www-data PHP_INI_SCAN_DIR=:<%= @cli_root %> "$SAKE_PATH" "$@"


### PR DESCRIPTION
Supporting this dash PR
https://github.com/silverstripeltd/dash/pull/248
given framework hasn't changed since this request
https://github.com/silverstripe/silverstripe-framework/pull/7909
I have found a workaround by loading an INI file called deploy.ini via the environment var PHP_INI_SCAN_DIR

it avoids the flow of deployments failing and the error logs go to syslog rather than stderr